### PR TITLE
Changes to adc.c and adc.h to remove errors.

### DIFF
--- a/hal/MSP430/MSP430F5529/hal_adc.c
+++ b/hal/MSP430/MSP430F5529/hal_adc.c
@@ -1,0 +1,73 @@
+#include <msp430.h>
+#include <stdint.h>
+
+#include "adc.h"
+#include "hal_adc.h"
+#include "project_settings.h"
+
+void hal_ADC_Init(void) {
+	ADC12CTL0 = ADC12SHT02 + ADC12ON;         // Sampling time, ADC12 on
+	ADC12CTL1 = ADC12SHP;                     // Use sampling timer
+	ADC12IE = 0x01;                           // Enable interrupt
+	ADC12CTL0 |= ADC12ENC;
+}
+
+void hal_ADC_StartChannel(uint8_t channel) {
+	switch(channel) {
+		case ADC0:
+			P6SEL |= 0x01;
+			break;
+		case ADC1:
+			P6SEL |= 0x02;
+			break;
+		case ADC2:
+			P6SEL |= 0x03;
+			break;
+		case ADC3:
+			P6SEL |= 0x04;
+			break;
+		case ADC4:
+			P6SEL |= 0x05;
+			break;
+		case ADC5:
+			P6SEL |= 0x06;
+			break;
+		case ADC6:
+			P6SEL |= 0x07;
+			break;
+		case ADC7:
+			P6SEL |= 0x08;
+			break;
+	}
+	
+	ADC12CTL0 |= ADC12SC;                   // Start sampling/conversion
+}
+
+#pragma vector = ADC12_VECTOR
+__interrupt void ADC12_ISR(void) {
+  switch(__even_in_range(ADC12IV,34))
+  {
+  case  0: break;                           // Vector  0:  No interrupt
+  case  2: break;                           // Vector  2:  ADC overflow
+  case  4: break;                           // Vector  4:  ADC timing overflow
+  case  6:                                  // Vector  6:  ADC12IFG0
+      ADC_ProcessMeasurementFromISR(ADC12MEM0);
+  case  8: break;                           // Vector  8:  ADC12IFG1
+  case 10: break;                           // Vector 10:  ADC12IFG2
+  case 12: break;                           // Vector 12:  ADC12IFG3
+  case 14: break;                           // Vector 14:  ADC12IFG4
+  case 16: break;                           // Vector 16:  ADC12IFG5
+  case 18: break;                           // Vector 18:  ADC12IFG6
+  case 20: break;                           // Vector 20:  ADC12IFG7
+  case 22: break;                           // Vector 22:  ADC12IFG8
+  case 24: break;                           // Vector 24:  ADC12IFG9
+  case 26: break;                           // Vector 26:  ADC12IFG10
+  case 28: break;                           // Vector 28:  ADC12IFG11
+  case 30: break;                           // Vector 30:  ADC12IFG12
+  case 32: break;                           // Vector 32:  ADC12IFG13
+  case 34: break;                           // Vector 34:  ADC12IFG14
+  default: break; 
+  }
+}
+
+

--- a/hal/MSP430/MSP430F5529/hal_adc.h
+++ b/hal/MSP430/MSP430F5529/hal_adc.h
@@ -1,0 +1,25 @@
+ /**
+ * @defgroup hal_adc HAL ADC Module
+ * @ingroup adc
+ * @file hal_adc.h
+ *
+ *  Created on: Mar 5, 2019
+ *      Author: Nikola Kosaric
+ * @todo Nikola Kosaric document this
+ * @{
+ */
+ 
+ #ifndef _HAL_ADC_H_
+#define _HAL_ADC_H_
+
+#define ADC0 0
+#define ADC1 1
+#define ADC2 2
+#define ADC3 3
+#define ADC4 4
+#define ADC5 5
+#define ADC6 6
+#define ADC7 7
+
+/** @}*/
+#endif /* _HAL_ADC_H_ */

--- a/include/adc.h
+++ b/include/adc.h
@@ -1,3 +1,7 @@
+#include <stdint.h>
+#include "task.h"
+#include "hal_general.h"
+
 #ifndef _ADC_H_
 #define _ADC_H_
 /**
@@ -24,7 +28,7 @@ void ADC_Init(void);
  * @param callback Callback when measurements are complete. Can be void Function(uint16_t value) or void Function(uint16_t value, void * ptr)
  * @param ptr Optional pointer to be passed to the callback function
  */
-void ADC_AddChannel(uint8_t channel; uint16_t period, void(*callback)(uint16_t, void *), void * ptr);
+void ADC_AddChannel(uint8_t channel, uint16_t period, void(*callback)(uint16_t, void *), void * ptr);
 
 /**
  * Function to be called from the ADC interrupt in hal_adc.c with the measurement
@@ -52,4 +56,6 @@ void hal_ADC_StartChannel(uint8_t channel);
 #define ADC_MAX_CHANNELS 8
 
  /** @} */
+
+
 #endif // _ADC_H_

--- a/src/adc.c
+++ b/src/adc.c
@@ -20,12 +20,10 @@ static struct adc_channel * pending_measurements[ADC_QUEUE_SIZE];
 static uint8_t start, end, full;
 
 
-// Initialized the QueueMeasurement functions. Should be initialized in the header file
-// however when attempted, it didn't work, need to try again
-void QueueMeasurement(struct adc_channel * channel);
+// Initialized the QueueMeasurement functions
+static void QueueMeasurement(struct adc_channel * channel);
 
-// Initialized the CallCallback functions. Should be initialized in the header file
-// however when attempted, it didn't work, need to try again
+// Initialized the CallCallback functions
 static void CallCallback(struct adc_channel * channel_struct);
 
 void ADC_Init(void) {
@@ -46,7 +44,7 @@ void ADC_AddChannel(uint8_t channel, uint16_t period, void(*callback)(uint16_t, 
 	}
 }
 
-void QueueMeasurement(struct adc_channel * channel) {
+static void QueueMeasurement(struct adc_channel * channel) {
 	// add measurement to the queue
 	if(!full) {
 		BlockInterrupts();
@@ -79,6 +77,6 @@ static void CallCallback(struct adc_channel * channel_struct) {
 	if(channel_struct->ptr) {
 		channel_struct->callback(channel_struct->value, channel_struct->ptr);
 	}else {
-		channel_struct->callback(channel_struct->value, 0);
+		(void(*)(uint16_t))channel_struct->callback(channel_struct->value);
 	}
 }

--- a/src/adc.c
+++ b/src/adc.c
@@ -19,17 +19,26 @@ static struct adc_channel * pending_measurements[ADC_QUEUE_SIZE];
 // full is a binary flag to indicate if the circular queue is full or not
 static uint8_t start, end, full;
 
+
+// Initialized the QueueMeasurement functions. Should be initialized in the header file
+// however when attempted, it didn't work, need to try again
+void QueueMeasurement(struct adc_channel * channel);
+
+// Initialized the CallCallback functions. Should be initialized in the header file
+// however when attempted, it didn't work, need to try again
+static void CallCallback(struct adc_channel * channel_struct);
+
 void ADC_Init(void) {
 	num_channels = 0;
 	start = 0;
 	end = 0;
 	full = 0;
-	hal_ADC_Init(void);
+	hal_ADC_Init();
 }
 
-void ADC_AddChannel(uint8_t channel; uint16_t period, void(*callback)(uint16_t, void *), void * ptr) {
+void ADC_AddChannel(uint8_t channel, uint16_t period, void(*callback)(uint16_t, void *), void * ptr) {
 	if(num_channels < ADC_MAX_CHANNELS) {
-		channels[num_channels].channel = channel
+		channels[num_channels].channel = channel;
 		channels[num_channels].callback = callback;
 		channels[num_channels].ptr = ptr;
 		Task_Schedule(QueueMeasurement, &channels[num_channels], period, period);
@@ -37,7 +46,7 @@ void ADC_AddChannel(uint8_t channel; uint16_t period, void(*callback)(uint16_t, 
 	}
 }
 
-static void QueueMeasurement(struct adc_channel * channel) {
+void QueueMeasurement(struct adc_channel * channel) {
 	// add measurement to the queue
 	if(!full) {
 		BlockInterrupts();
@@ -70,6 +79,6 @@ static void CallCallback(struct adc_channel * channel_struct) {
 	if(channel_struct->ptr) {
 		channel_struct->callback(channel_struct->value, channel_struct->ptr);
 	}else {
-		channel_struct->callback(channel_struct->value);
+		channel_struct->callback(channel_struct->value, 0);
 	}
 }


### PR DESCRIPTION
Initialization of QueueMeasurement and CallCallback should be moved to the headerfile rather than being initialized in the .c file