### PR TITLE
added typedef for casting callback fnc without optional pointer

### DIFF
--- a/include/adc.h
+++ b/include/adc.h
@@ -19,10 +19,10 @@
  * void(*callback)(uint16_t, void *) to avoid compiler error/warning.
  *
  * For example an ADC channel with the following callback:
- * void callback(uint16_t AdcVal, uint8_t status);
+ * void callback (uint16_t value);
  * 
  * Would added as:
- * ADC_AddChannel(channel, period, (callback_input_t)callback, status);
+ * ADC_AddChannel(channel, period, (callback_input_t)callback, 0);
  *
  * @author Page
  */

--- a/include/adc.h
+++ b/include/adc.h
@@ -26,7 +26,7 @@
  *
  * @author Page
  */
-typedef void(*callback_input_t)(uint16_t,void);
+typedef void(*callback_input_t)(uint16_t, void *);
 
 /** @brief Initialize the ADC module
  * 

--- a/include/adc.h
+++ b/include/adc.h
@@ -7,7 +7,14 @@
  *
  * @{
  */
- 
+/**
+ * @brief helpful typedef for call back
+ *
+ * To be used in adc.c where the call back is used without the optional pointer
+ *
+ * @author Page
+ */
+typedef void(*callback_no_input_t)(uint16_t);
 /** @brief Initialize the ADC module
  * 
  * This is the longer description which uses more words to say initializes the ADC module.

--- a/include/adc.h
+++ b/include/adc.h
@@ -11,14 +11,23 @@
  *
  * @{
  */
+ 
 /**
- * @brief helpful typedef for call back
+ * @brief helpful typedef for adc callback with input
  *
- * To be used in adc.c where the call back is used without the optional pointer
+ * To be used with the function ADC_AddChannel for callbacks that do not match the form 
+ * void(*callback)(uint16_t, void *) to avoid compiler error/warning.
+ *
+ * For example an ADC channel with the following callback:
+ * void callback(uint16_t AdcVal, uint8_t status);
+ * 
+ * Would added as:
+ * ADC_AddChannel(channel, period, (callback_input_t)callback, status);
  *
  * @author Page
  */
-typedef void(*callback_no_input_t)(uint16_t);
+typedef void(*callback_input_t)(uint16_t,void);
+
 /** @brief Initialize the ADC module
  * 
  * This is the longer description which uses more words to say initializes the ADC module.

--- a/src/adc.c
+++ b/src/adc.c
@@ -70,6 +70,7 @@ static void CallCallback(struct adc_channel * channel_struct) {
 	if(channel_struct->ptr) {
 		channel_struct->callback(channel_struct->value, channel_struct->ptr);
 	}else {
-		channel_struct->callback(channel_struct->value);
+		// typedef to cast callback to have only one input
+		((callback_no_input_t)channel_struct->callback)(channel_struct->value);
 	}
 }

--- a/src/adc.c
+++ b/src/adc.c
@@ -26,6 +26,9 @@ static void QueueMeasurement(struct adc_channel * channel);
 // Initialized the CallCallback functions
 static void CallCallback(struct adc_channel * channel_struct);
 
+//To be used in adc.c where the call back is used without the optional pointer
+typedef void(*callback_no_input_t)(uint16_t);
+
 void ADC_Init(void) {
 	num_channels = 0;
 	start = 0;


### PR DESCRIPTION
Contains a working adc.c and .h. Was pulled after Nikola's pull request was approved.