### PR TITLE
Add cast for XC16 compiler

### DIFF
--- a/src/adc.c
+++ b/src/adc.c
@@ -39,7 +39,7 @@ void ADC_AddChannel(uint8_t channel, uint16_t period, void(*callback)(uint16_t, 
 		channels[num_channels].channel = channel;
 		channels[num_channels].callback = callback;
 		channels[num_channels].ptr = ptr;
-		Task_Schedule(QueueMeasurement, &channels[num_channels], period, period);
+		Task_Schedule((task_t) QueueMeasurement, &channels[num_channels], period, period);
 		num_channels++;
 	}
 }
@@ -62,7 +62,7 @@ static void QueueMeasurement(struct adc_channel * channel) {
 // must be interrupt safe
 void ADC_ProcessMeasurementFromISR(uint16_t value) {
 	pending_measurements[start]->value = value;
-	Task_Queue(CallCallback, pending_measurements[start]);
+	Task_Queue((task_t) CallCallback, pending_measurements[start]);
 	full = 0;
 	start++;
 	if(start >= ADC_QUEUE_SIZE) start = 0;


### PR DESCRIPTION
This PR along with #5 fix issues building with the XC16 compiler.  This code has executed successfully on a dsPIC33EV256GM102 processor.

The error this fixes is included below:

```
../../embedded-software/src/adc.c:65:2: warning: passing argument 1 of 'Task_Queue' from incompatible pointer type
../../embedded-software/include/task.h:121:6: note: expected 'task_t' but argument is of type 'void (*)(struct adc_channel *)'
```