### PR TITLE
Add missing include for XC16 compiler

### DIFF
--- a/hal/dsPIC33/dsPIC33EV256GM102/strings.h
+++ b/hal/dsPIC33/dsPIC33EV256GM102/strings.h
@@ -14,6 +14,8 @@
 #ifndef STRINGS_H
 #define STRINGS_H
 
+#include "stddef.h"
+
 int strcasecmp(const char *, const char *);
 int strncasecmp(const char *, const char *, size_t);
 


### PR DESCRIPTION
Discovered while porting Muh_Game over to dsPIC.  strings.h did not have a definition for what size_t was.